### PR TITLE
refactor(src): refactor regex to blacklist all numbers or letters

### DIFF
--- a/src/passwordcheck.js
+++ b/src/passwordcheck.js
@@ -28,10 +28,10 @@ define(['bloomfilter',
         PASSWORD_TOO_SHORT: 'PASSWORD_TOO_SHORT'
       };
 
-      function isStrongEnough(password) {
-        // Check for passwords that at least contain a number and an alphabet,
-        // or if alphabets, then at least (minLength + 4) characters long
-        var regexString = '((?=.*[a-zA-Z])(?=.*[0-9])[A-Za-z0-9!@#$%^&*()_+ ]{' + minLength + ',' + (minLength + 4) + '})|([A-Za-z0-9!@#$%^&*()_+ ]{' + (minLength + 4) + ',})';
+      function isWeakPassword(password) {
+        // Check for passwords that consist of only numbers
+        // or only alphabets, and are of length less than (minlength + 4)
+        var regexString = '([a-zA-Z]){' + minLength + ',' + (minLength + 4) + '}|([0-9]){' + minLength + ',' + (minLength + 4) + '}';
         var regex = new RegExp(regexString);
         return regex.test(password);
       }
@@ -46,7 +46,7 @@ define(['bloomfilter',
         // password is non-empty, a string and length greater
         // than minimum length we can start checking
         // for password strength
-        } else if (! isStrongEnough(password)) {
+        } else if (isWeakPassword(password)) {
           callback(MESSAGES.NOT_STRONG_ENOUGH);
         // Only if the password has a chance of being
         // strong do we check with the bloom filter

--- a/tests/password_checker_test.js
+++ b/tests/password_checker_test.js
@@ -19,13 +19,13 @@
       });
     });
 
-    it('returns ALL_LETTERS_NUMBERS when password is all numbers', function () {
-      passwordcheck('12456789', function (res) {
+    it('returns NOT_STRONG_ENOUGH when password is all numbers', function () {
+      passwordcheck('124567890', function (res) {
         assert.equal('NOT_STRONG_ENOUGH', res);
       });
     });
 
-    it('returns ALL_LETTERS_NUMBERS when password is all letters', function () {
+    it('returns NOT_STRONG_ENOUGH when password is all letters', function () {
       passwordcheck('dragondrag', function (res) {
         assert.equal('NOT_STRONG_ENOUGH', res);
       });


### PR DESCRIPTION
refactor the regex to simplify usage, and to blacklist bad passwords instead of whitelisting strong passwords.
